### PR TITLE
small changes for deployment

### DIFF
--- a/server/app/query/servers.tsx
+++ b/server/app/query/servers.tsx
@@ -268,18 +268,18 @@ export class IPACoordinatorRemoteServer extends RemoteServer {
 export const IPARemoteServers: RemoteServersType = {
   [RemoteServerNames.Coordinator]: new IPACoordinatorRemoteServer(
     RemoteServerNames.Coordinator,
-    new URL("http://localhost:17430"),
+    new URL(process?.env?.COORDINATOR_URL ?? "http://localhost:17430"),
   ),
   [RemoteServerNames.Helper1]: new IPAHelperRemoteServer(
     RemoteServerNames.Helper1,
-    new URL("http://localhost:17431"),
+    new URL(process?.env?.Helper1_URL ?? "http://localhost:17431"),
   ),
   [RemoteServerNames.Helper2]: new IPAHelperRemoteServer(
     RemoteServerNames.Helper2,
-    new URL("http://localhost:17432"),
+    new URL(process?.env?.Helper2_URL ?? "http://localhost:17432"),
   ),
   [RemoteServerNames.Helper3]: new IPAHelperRemoteServer(
     RemoteServerNames.Helper3,
-    new URL("http://localhost:17433"),
+    new URL(process?.env?.Helper3_URL ?? "http://localhost:17433"),
   ),
 };

--- a/sidecar/cli/cli.py
+++ b/sidecar/cli/cli.py
@@ -37,6 +37,7 @@ def start_helper_sidecar_command(
         "NETWORK_CONFIG_PATH": network_config,
         "PRIVATE_KEY_PEM_PATH": private_key_pem_path,
         "UVICORN_PORT": str(helper.sidecar_port),
+        "UVICORN_HOST": "0.0.0.0",
     }
     return Command(cmd=cmd, env=env)
 


### PR DESCRIPTION
runs uvicorn on 0.0.0.0 when running individual helper, and allows for helper URLs to be set in the environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved server connection setup to allow for more flexible deployments.
- **Chores**
	- Configured the helper sidecar to accept connections on all network interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->