### PR TITLE
Form race condition

### DIFF
--- a/server/app/query/create/page.tsx
+++ b/server/app/query/create/page.tsx
@@ -323,9 +323,10 @@ function IPAForm({
         type="submit"
         className={clsx(
           "mt-4 inline-flex items-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600",
-          !validCommitHash && "opacity-25 hover:bg-emerald-600",
+          (!validCommitHash || selectedCommitHash === "") &&
+            "opacity-25 hover:bg-emerald-600",
         )}
-        disabled={!validCommitHash}
+        disabled={!validCommitHash || selectedCommitHash === ""}
       >
         Start Query
       </button>

--- a/server/app/query/create/page.tsx
+++ b/server/app/query/create/page.tsx
@@ -31,7 +31,6 @@ export default function Page() {
       const newQueryId = NewQueryId();
       setQueryId(newQueryId);
       // Send a POST request to start the process
-      console.log("sending post");
       const formData = new FormData(event.currentTarget);
       for (const remoteServer of Object.values(remoteServers)) {
         const response = await fetch(remoteServer.startURL(newQueryId), {
@@ -39,11 +38,8 @@ export default function Page() {
           body: formData,
         });
         const data = await response.json();
-        console.log(remoteServer);
-        console.log(data);
       }
 
-      // const data = await response.json();
       await new Promise((f) => setTimeout(f, 1000));
 
       // Redirect to /query/view/<newQueryId>


### PR DESCRIPTION
you always find funny bugs when using in flight wifi... turns out the commit hash doesn't populate until the octokit api is called, and that can have some delay. POSTing a form without it raises and error, so we can just disable that until it's loaded.

note: we could have also had the `validCommitHash` initialize as `false` but then we get bad UX, because invalid hash warnings then appear on page load and then disappear when the API loads the commit hash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed unnecessary console logs in the Page component.
	- Updated logic for disabling the "Start Query" button to improve usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->