### PR TITLE
fix caching of github api, only fetch 300 commits

### DIFF
--- a/server/app/query/create/page.tsx
+++ b/server/app/query/create/page.tsx
@@ -182,7 +182,7 @@ function IPAForm({
       setBranches(_branches);
     };
     const fetchCommitHashes = async () => {
-      const _commitHashes = await Commits(owner, repo, false);
+      const _commitHashes = await Commits(owner, repo, false, 300);
       setCommitHashes(_commitHashes);
     };
     fetchBranches().catch(console.error);
@@ -192,7 +192,7 @@ function IPAForm({
   const refreshBranches = async (selectedCommitHash: string) => {
     const _branches = await Branches(owner, repo, true);
     setBranches(_branches);
-    const _commitHashes = await Commits(owner, repo, true);
+    const _commitHashes = await Commits(owner, repo, true, 300);
     setCommitHashes(_commitHashes);
   };
 

--- a/server/app/query/github.tsx
+++ b/server/app/query/github.tsx
@@ -31,7 +31,7 @@ export async function Branches(
     request: {
       cache: bypassCache ? "reload" : "default",
     },
-    timestamp: new Date().getTime(),
+    timestamp: bypassCache ? new Date().getTime() : "",
   };
   const branchesIter = octokit.paginate.iterator(
     octokit.rest.repos.listBranches,
@@ -56,7 +56,7 @@ export async function Branches(
     request: {
       cache: bypassCache ? "reload" : "default",
     },
-    timestamp: new Date().getTime(),
+    timestamp: bypassCache ? new Date().getTime() : "",
   };
 
   const pullRequestsIter = octokit.paginate.iterator(
@@ -86,6 +86,7 @@ export async function Commits(
   owner: string,
   repo: string,
   bypassCache: boolean,
+  maxCommits: number,
 ): Promise<string[]> {
   const requestParams: any = {
     owner: owner,
@@ -94,7 +95,7 @@ export async function Commits(
     request: {
       cache: bypassCache ? "reload" : "default",
     },
-    timestamp: new Date().getTime(),
+    timestamp: bypassCache ? new Date().getTime() : "",
   };
   const commitsIter = octokit.paginate.iterator(
     octokit.rest.repos.listCommits,
@@ -102,9 +103,14 @@ export async function Commits(
   );
 
   let commitsArray: string[] = [];
+  let pages: number = 0;
   for await (const { data: commits } of commitsIter) {
     for (const commit of commits) {
       commitsArray.push(commit.sha);
+    }
+    pages++;
+    if (pages * 100 > maxCommits) {
+      break;
     }
   }
   return commitsArray;

--- a/server/app/query/github.tsx
+++ b/server/app/query/github.tsx
@@ -31,7 +31,7 @@ export async function Branches(
     request: {
       cache: bypassCache ? "reload" : "default",
     },
-    timestamp: bypassCache ? new Date().getTime() : "",
+    timestamp: bypassCache ? new Date().getTime().toString() : "",
   };
   const branchesIter = octokit.paginate.iterator(
     octokit.rest.repos.listBranches,
@@ -56,7 +56,7 @@ export async function Branches(
     request: {
       cache: bypassCache ? "reload" : "default",
     },
-    timestamp: bypassCache ? new Date().getTime() : "",
+    timestamp: bypassCache ? new Date().getTime().toString() : "",
   };
 
   const pullRequestsIter = octokit.paginate.iterator(
@@ -95,7 +95,7 @@ export async function Commits(
     request: {
       cache: bypassCache ? "reload" : "default",
     },
-    timestamp: bypassCache ? new Date().getTime() : "",
+    timestamp: bypassCache ? new Date().getTime().toString() : "",
   };
   const commitsIter = octokit.paginate.iterator(
     octokit.rest.repos.listCommits,

--- a/server/next.config.js
+++ b/server/next.config.js
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
fetching all commit hashes is unnecessary and takes over 10 seconds, so it times out. this gets the last 300, and also makes the cache work (unless the refresh button is pressed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced commit fetching in the IPAForm to support fetching up to 300 commits.
	- Introduced full URL logging for fetch operations to improve transparency and debugging.

- **Bug Fixes**
	- Updated timestamp handling in GitHub queries to ensure accuracy when bypassing cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->