### PR TITLE
update deployment scripts to properly start and stop sidecar

### DIFF
--- a/ansible/deploy.yaml
+++ b/ansible/deploy.yaml
@@ -1,8 +1,14 @@
 - name: Deploy updates to Draft
   hosts: all
   tasks:
-    # - name: Stop helper sidecar
-    #   command: '{{ ansible_env.HOME }}/draft/.venv/bin/draft stop-helper-sidecar'
+    - name: Stop helper sidecar
+      shell: >
+        source .venv/bin/activate &&
+        draft stop-helper-sidecar
+      args:
+        chdir: '{{ ansible_env.HOME }}/draft'
+        executable: /bin/bash
+
     - name: Pull new commits from GitHub
       git:
         repo: 'https://github.com/private-attribution/draft.git'
@@ -12,5 +18,14 @@
       command: git pull origin main
       args:
         chdir: '{{ ansible_env.HOME }}/draft'
-    # - name: Start helper sidecar
-    #   command: '{{ ansible_env.HOME }}/draft/.venv/bin/draft start-helper-sidecar'
+    - name: Start helper sidecar
+      shell: >
+        source .venv/bin/activate &&
+        draft start-helper-sidecar
+        --identity {{ identity }}
+        --root_domain {{ root_domain }}
+        --sidecar_domain sidecar{{ identity }}.{{ root_domain }}
+        --config_path {{ ansible_env.HOME }}/draft/config
+      args:
+        chdir: '{{ ansible_env.HOME }}/draft'
+        executable: /bin/bash

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,7 +1,8 @@
 [myhosts]
-ipa-dev
-ipa-1
-ipa-2
-ipa-3
+ipa-dev identity=0
+ipa-1 identity=1
+ipa-2 identity=2
+ipa-3 identity=3
 [myhosts:vars]
 ansible_python_interpreter=/usr/bin/python3
+root_domain=ipa-helper.dev

--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -86,7 +86,17 @@
       copy:
         src: '{{ ansible_env.HOME }}/traefix_extract/traefik'
         dest: '{{ ansible_env.HOME }}/draft'
+        mode: '0775'
         remote_src: yes
 
-    - name: Run draft start-helper-sidecar
-      command: '{{ ansible_env.HOME }}/draft/.venv/bin/draft start-helper-sidecar'
+    - name: Start helper sidecar
+      shell: >
+        source .venv/bin/activate &&
+        draft start-helper-sidecar
+        --identity {{ identity }}
+        --root_domain {{ root_domain }}
+        --sidecar_domain sidecar{{ identity }}.{{ root_domain }}
+        --config_path {{ ansible_env.HOME }}/draft/config
+      args:
+        chdir: '{{ ansible_env.HOME }}/draft'
+        executable: /bin/bash

--- a/sidecar/cli/cli.py
+++ b/sidecar/cli/cli.py
@@ -188,7 +188,7 @@ def start_helper_sidecar(
         f"{sidecar_domain} {helper_port} {sidecar_port} {identity}",
     )
     start_command.run_blocking_no_output_capture()
-    print("draft local-dev started")
+    print("draft helper_sidecar started")
 
 
 @cli.command


### PR DESCRIPTION
makes the deployment actually work by:
1. using the virtualenvs (required up and down the call stack)
2. providing all the needed input to `start-helper-sidecar`
3. making sure the traefik binary is executable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved deployment process with new shell commands for starting and stopping the helper sidecar.
  - Added specific configurations for starting the helper sidecar.

- **Configuration Updates**
  - Added `identity` parameter and `root_domain` variable to hosts in the inventory file for better identification and management.
  
- **Task Modifications**
  - Updated provisioning tasks to use shell commands with environment setup and additional arguments for better control and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->