### PR TITLE
remove need for calling traefik with sudo

### DIFF
--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -89,6 +89,12 @@
         mode: '0775'
         remote_src: yes
 
+    - name: Grant CAP_NET_BIND_SERVICE capability to traefik binary
+      command:
+        cmd: 'setcap cap_net_bind_service=+ep {{ ansible_env.HOME }}/draft/traefik'
+      warn: no
+      become: yes
+
     - name: Start helper sidecar
       shell: >
         source .venv/bin/activate &&

--- a/sidecar/cli/cli.py
+++ b/sidecar/cli/cli.py
@@ -87,7 +87,7 @@ def start_traefik_command(
         "SIDECAR_PORT": str(sidecar_port),
         "CERT_DIR": config_path,
     }
-    cmd = "sudo -E ./traefik --configFile=sidecar/traefik/traefik.yaml"
+    cmd = "./traefik --configFile=sidecar/traefik/traefik.yaml"
     return Command(cmd=cmd, env=env)
 
 


### PR DESCRIPTION
quick fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved `traefik` setup by granting necessary permissions automatically.
  - Simplified the `traefik` startup command, removing the need for `sudo`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->