### PR TITLE
add gate-type and stall-detection to binary name for proper caching

### DIFF
--- a/sidecar/app/query/ipa.py
+++ b/sidecar/app/query/ipa.py
@@ -169,9 +169,12 @@ class IPAHelperCompileStep(LoggerOutputCommandStep):
     @classmethod
     def build_from_query(cls, query: IPAHelperQuery):
         manifest_path = query.paths.repo_path / Path("Cargo.toml")
-        target_path = query.paths.repo_path / Path(f"target-{query.paths.commit_hash}")
         gate_type = query.gate_type
         stall_detection = query.stall_detection
+        target_path = query.paths.repo_path / Path(
+            f"target-{query.paths.commit_hash}-{gate_type}"
+            f"{'-stall-detection' if stall_detection else ''}"
+        )
         return cls(
             manifest_path=manifest_path,
             target_path=target_path,


### PR DESCRIPTION
make sure the cached binaries take into account the compile flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced target path naming for better clarity and organization by including `gate_type` and `stall_detection` parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->