### PR TITLE
prevent start from running if pid file exists

### DIFF
--- a/etc/start_helper_sidecar.sh
+++ b/etc/start_helper_sidecar.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+pid_file=".draft/pids/helper_sidecar.pid"
+# Check if pid file exists
+if [ -f "$pid_file" ]; then
+    echo "Error: $pid_file already exists."
+    exit 1
+fi
+
 config_path=$1
 root_path=$2
 root_domain=$3
@@ -8,4 +15,4 @@ helper_port=$5
 sidecar_port=$6
 identity=$7
 
-nohup draft run-helper-sidecar --config_path "$config_path" --root_path "$root_path" --root_domain "$root_domain" --sidecar_domain "$sidecar_domain" --helper_port "$helper_port" --sidecar_port "$sidecar_port" --identity "$identity" > .draft/logs/helper_sidecar.log 2>&1 & echo $! > .draft/pids/helper_sidecar.pid
+nohup draft run-helper-sidecar --config_path "$config_path" --root_path "$root_path" --root_domain "$root_domain" --sidecar_domain "$sidecar_domain" --helper_port "$helper_port" --sidecar_port "$sidecar_port" --identity "$identity" > .draft/logs/helper_sidecar.log 2>&1 & echo $! > $pid_file

--- a/etc/start_local_dev.sh
+++ b/etc/start_local_dev.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+pid_file=".draft/pids/local_dev.pid"
+# Check if pid file exists
+if [ -f "$pid_file" ]; then
+    echo "Error: $pid_file already exists."
+    exit 1
+fi
+
 config_path=$1
 root_path=$2
 helper_start_port=$3
 sidecar_start_port=$4
 
-nohup draft run-local-dev --config_path "$config_path" --root_path "$root_path" --helper_start_port "$helper_start_port" --sidecar_start_port "$sidecar_start_port" > .draft/logs/local_dev.log 2>&1 & echo $! > .draft/pids/local_dev.pid
+nohup draft run-local-dev --config_path "$config_path" --root_path "$root_path" --helper_start_port "$helper_start_port" --sidecar_start_port "$sidecar_start_port" > .draft/logs/local_dev.log 2>&1 & echo $! > $pid_file


### PR DESCRIPTION
small change so that start doesn't get run twice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced startup scripts to check for existing PID files before starting processes, preventing multiple instances from running.
  - Updated scripts to use variables for PID file paths, improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->