### PR TITLE
add multi-threading toggle, fix binary caching string

### DIFF
--- a/server/app/query/create/page.tsx
+++ b/server/app/query/create/page.tsx
@@ -127,6 +127,7 @@ function IPAForm({
     CommitSpecifier.BRANCH,
   );
   const [stallDetectionEnabled, setStallDetectionEnabled] = useState(true);
+  const [multiThreadingEnabled, setMultiThreadingEnabled] = useState(true);
   const disableBranch = commitSpecifier != CommitSpecifier.BRANCH;
   const disableCommitHash = commitSpecifier != CommitSpecifier.COMMIT_HASH;
   const filteredCommitHashes =
@@ -298,7 +299,7 @@ function IPAForm({
 
       <div className="relative pt-4">
         <div className="block text-sm font-medium leading-6 text-gray-900">
-          Size
+          Input Size
         </div>
 
         <input
@@ -349,6 +350,28 @@ function IPAForm({
             <span
               className={`${
                 stallDetectionEnabled ? "translate-x-6" : "translate-x-1"
+              } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+            />
+          </Switch>
+        </div>
+      </div>
+
+      <div className="items-center pt-4">
+        <div className="block text-sm font-medium leading-6 text-gray-900">
+          Multi-threading
+        </div>
+        <div className="block pt-1 text-sm font-medium leading-6 text-gray-900">
+          <Switch
+            checked={multiThreadingEnabled}
+            onChange={setMultiThreadingEnabled}
+            name="multi_threading"
+            className={`${
+              multiThreadingEnabled ? "bg-blue-600" : "bg-gray-200"
+            } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+          >
+            <span
+              className={`${
+                multiThreadingEnabled ? "translate-x-6" : "translate-x-1"
               } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
             />
           </Switch>

--- a/sidecar/app/local_paths.py
+++ b/sidecar/app/local_paths.py
@@ -7,7 +7,7 @@ from typing import Optional
 class Paths:
     repo_path: Path
     config_path: Path
-    commit_hash: str
+    compiled_id: str
     _test_data_path: Optional[Path] = None
 
     @property
@@ -22,7 +22,7 @@ class Paths:
 
     @property
     def target_path(self) -> Path:
-        return self.repo_path / Path(f"target-{self.commit_hash}")
+        return self.repo_path / Path(f"target-{self.compiled_id}")
 
     @property
     def helper_binary_path(self) -> Path:


### PR DESCRIPTION
adds a toggle for multi-threading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a multi-threading option in the IPAForm component, allowing users to enable or disable multi-threading for their queries.

- **Enhancements**
  - Updated target path construction to use `compiled_id` instead of `commit_hash`, improving consistency and clarity.

- **Bug Fixes**
  - Adjusted internal logic to ensure the new multi-threading option is correctly passed and utilized within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->