### PR TITLE
add flag for disabling metrics

### DIFF
--- a/server/app/query/create/page.tsx
+++ b/server/app/query/create/page.tsx
@@ -128,6 +128,7 @@ function IPAForm({
   );
   const [stallDetectionEnabled, setStallDetectionEnabled] = useState(true);
   const [multiThreadingEnabled, setMultiThreadingEnabled] = useState(true);
+  const [disableMetricsEnabled, setDisableMetricsEnabled] = useState(false);
   const disableBranch = commitSpecifier != CommitSpecifier.BRANCH;
   const disableCommitHash = commitSpecifier != CommitSpecifier.COMMIT_HASH;
   const filteredCommitHashes =
@@ -372,6 +373,28 @@ function IPAForm({
             <span
               className={`${
                 multiThreadingEnabled ? "translate-x-6" : "translate-x-1"
+              } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+            />
+          </Switch>
+        </div>
+      </div>
+
+      <div className="items-center pt-4">
+        <div className="block text-sm font-medium leading-6 text-gray-900">
+          Disable metrics
+        </div>
+        <div className="block pt-1 text-sm font-medium leading-6 text-gray-900">
+          <Switch
+            checked={disableMetricsEnabled}
+            onChange={setDisableMetricsEnabled}
+            name="disable_metrics"
+            className={`${
+              disableMetricsEnabled ? "bg-blue-600" : "bg-gray-200"
+            } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+          >
+            <span
+              className={`${
+                disableMetricsEnabled ? "translate-x-6" : "translate-x-1"
               } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
             />
           </Switch>

--- a/sidecar/app/query/ipa.py
+++ b/sidecar/app/query/ipa.py
@@ -164,6 +164,7 @@ class IPAHelperCompileStep(LoggerOutputCommandStep):
     gate_type: GateType
     stall_detection: bool
     multi_threading: bool
+    disable_metrics: bool
     logger: loguru.Logger = field(repr=False)
     status: ClassVar[Status] = Status.COMPILING
 
@@ -173,12 +174,14 @@ class IPAHelperCompileStep(LoggerOutputCommandStep):
         gate_type = query.gate_type
         stall_detection = query.stall_detection
         multi_threading = query.multi_threading
+        disable_metrics = query.disable_metrics
         return cls(
             manifest_path=manifest_path,
             target_path=query.paths.target_path,
             gate_type=gate_type,
             stall_detection=stall_detection,
             multi_threading=multi_threading,
+            disable_metrics=disable_metrics,
             logger=query.logger,
         )
 
@@ -187,7 +190,8 @@ class IPAHelperCompileStep(LoggerOutputCommandStep):
             cmd=f"cargo build --bin helper --manifest-path={self.manifest_path} "
             f'--features="web-app real-world-infra {self.gate_type}'
             f"{' stall-detection' if self.stall_detection else ''}"
-            f"{' multi-threading' if self.multi_threading else ''}\" "
+            f"{' multi-threading' if self.multi_threading else ''}"
+            f"{' disable-metrics' if self.disable_metrics else ''}\" "
             f"--no-default-features --target-dir={self.target_path} "
             f"--release",
             logger=self.logger,
@@ -402,6 +406,7 @@ class IPAHelperQuery(IPAQuery):
     gate_type: GateType
     stall_detection: bool
     multi_threading: bool
+    disable_metrics: bool
 
     step_classes: ClassVar[list[type[Step]]] = [
         IPACloneStep,

--- a/sidecar/app/routes/start.py
+++ b/sidecar/app/routes/start.py
@@ -42,6 +42,7 @@ def start_ipa_helper(
     gate_type: Annotated[str, Form()],
     stall_detection: Annotated[bool, Form()],
     multi_threading: Annotated[bool, Form()],
+    disable_metrics: Annotated[bool, Form()],
     background_tasks: BackgroundTasks,
 ):
     # pylint: disable=too-many-arguments
@@ -53,6 +54,7 @@ def start_ipa_helper(
         f"{commit_hash}_{gate_type}"
         f"{'_stall-detection' if stall_detection else ''}"
         f"{'_multi-threading' if multi_threading else ''}"
+        f"{'_disable-metrics' if disable_metrics else ''}"
     )
 
     paths = Paths(
@@ -67,6 +69,7 @@ def start_ipa_helper(
         gate_type=GateType[gate_type.upper()],
         stall_detection=stall_detection,
         multi_threading=multi_threading,
+        disable_metrics=disable_metrics,
         port=settings.helper_port,
     )
     background_tasks.add_task(query.start)


### PR DESCRIPTION
cc @ akoshelev

This adds the `disable-metrics` flag to compiling the helper binary:

1. `server/app/query/create/page.tsx` adds the new field to the form
2. `sidecar/app/routes/start.py` accepts that form field when starting a query
3. `sidecar/app/query/ipa.py` uses that input to construct the compile command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option to disable metrics in the form, enhancing customization for users who prefer not to include metrics.
  
- **Improvements**
  - Enhanced the build process to respect the new disable metrics option, providing more control over the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->