### PR TITLE
add helper_parties and helper_party_network tables

### DIFF
--- a/server/data/supabaseTypes.ts
+++ b/server/data/supabaseTypes.ts
@@ -34,6 +34,78 @@ export type Database = {
   }
   public: {
     Tables: {
+      helper_parties: {
+        Row: {
+          created_at: string
+          display_name: string
+          uuid: string
+        }
+        Insert: {
+          created_at?: string
+          display_name: string
+          uuid?: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string
+          uuid?: string
+        }
+        Relationships: []
+      }
+      helper_party_network_members: {
+        Row: {
+          created_at: string
+          helper_party_network_uuid: string
+          helper_party_uuid: string
+        }
+        Insert: {
+          created_at?: string
+          helper_party_network_uuid: string
+          helper_party_uuid: string
+        }
+        Update: {
+          created_at?: string
+          helper_party_network_uuid?: string
+          helper_party_uuid?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "helper_party_network_members_helper_party_network_uuid_fkey"
+            columns: ["helper_party_network_uuid"]
+            isOneToOne: false
+            referencedRelation: "helper_party_networks"
+            referencedColumns: ["uuid"]
+          },
+          {
+            foreignKeyName: "helper_party_network_members_helper_party_uuid_fkey"
+            columns: ["helper_party_uuid"]
+            isOneToOne: false
+            referencedRelation: "helper_parties"
+            referencedColumns: ["uuid"]
+          },
+        ]
+      }
+      helper_party_networks: {
+        Row: {
+          created_at: string
+          display_name: string
+          size: number
+          uuid: string
+        }
+        Insert: {
+          created_at?: string
+          display_name: string
+          size: number
+          uuid?: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string
+          size?: number
+          uuid?: string
+        }
+        Relationships: []
+      }
       queries: {
         Row: {
           created_at: string

--- a/server/data/supabaseTypes.ts
+++ b/server/data/supabaseTypes.ts
@@ -38,16 +38,19 @@ export type Database = {
         Row: {
           created_at: string
           display_name: string
+          modified_at: string
           uuid: string
         }
         Insert: {
           created_at?: string
           display_name: string
+          modified_at?: string
           uuid?: string
         }
         Update: {
           created_at?: string
           display_name?: string
+          modified_at?: string
           uuid?: string
         }
         Relationships: []
@@ -89,16 +92,19 @@ export type Database = {
         Row: {
           created_at: string
           display_name: string
+          modified_at: string
           uuid: string
         }
         Insert: {
           created_at?: string
           display_name: string
+          modified_at?: string
           uuid?: string
         }
         Update: {
           created_at?: string
           display_name?: string
+          modified_at?: string
           uuid?: string
         }
         Relationships: []

--- a/server/data/supabaseTypes.ts
+++ b/server/data/supabaseTypes.ts
@@ -89,19 +89,16 @@ export type Database = {
         Row: {
           created_at: string
           display_name: string
-          size: number
           uuid: string
         }
         Insert: {
           created_at?: string
           display_name: string
-          size: number
           uuid?: string
         }
         Update: {
           created_at?: string
           display_name?: string
-          size?: number
           uuid?: string
         }
         Relationships: []

--- a/server/supabase/migrations/20240608204813_helper_party.sql
+++ b/server/supabase/migrations/20240608204813_helper_party.sql
@@ -1,0 +1,76 @@
+create table
+helper_parties (
+uuid uuid default gen_random_uuid() primary key,
+display_name varchar(255) unique not null,
+created_at timestamp default current_timestamp not null
+);
+
+alter table helper_parties enable row level security;
+
+create policy "Helper Parties are visible to authenticated users"
+on helper_parties for select
+to authenticated
+using ( true );
+
+create policy "Helper Parties are only created by authenticated users"
+on helper_parties for insert
+to authenticated
+with check ( true );
+
+create policy "Helper Parties are only updated by authenticated users"
+on helper_parties for update
+to authenticated
+using ( true )
+with check ( true );
+
+create table
+helper_party_networks (
+uuid uuid default gen_random_uuid() primary key,
+display_name varchar(255) unique not null,
+size smallint not null,
+created_at timestamp default current_timestamp not null
+);
+
+alter table helper_party_networks enable row level security;
+
+create policy "Helper Party Networks are visible to authenticated users"
+on helper_party_networks for select
+to authenticated
+using ( true );
+
+create policy "Helper Party Networks are only created by authenticated users"
+on helper_party_networks for insert
+to authenticated
+with check ( true );
+
+create policy "Helper Party Networks are only updated by authenticated users"
+on helper_party_networks for update
+to authenticated
+using ( true )
+with check ( true );
+
+create table
+helper_party_network_members (
+helper_party_uuid uuid references helper_parties not null,
+helper_party_network_uuid uuid references helper_party_networks not null,
+created_at timestamp default current_timestamp not null,
+primary key (helper_party_uuid, helper_party_network_uuid)
+);
+
+alter table helper_party_network_members enable row level security;
+
+create policy "Helper Party Network Members are visible to authenticated users"
+on helper_party_network_members for select
+to authenticated
+using ( true );
+
+create policy "Helper Party Network Members are only created by authenticated users"
+on helper_party_network_members for insert
+to authenticated
+with check ( true );
+
+create policy "Helper Party Network Members are only updated by authenticated users"
+on helper_party_network_members for update
+to authenticated
+using ( true )
+with check ( true );

--- a/server/supabase/migrations/20240608204813_helper_party.sql
+++ b/server/supabase/migrations/20240608204813_helper_party.sql
@@ -27,7 +27,6 @@ create table
 helper_party_networks (
 uuid uuid default gen_random_uuid() primary key,
 display_name varchar(255) unique not null,
-size smallint not null,
 created_at timestamp default current_timestamp not null
 );
 

--- a/server/supabase/migrations/20240608204813_helper_party.sql
+++ b/server/supabase/migrations/20240608204813_helper_party.sql
@@ -2,7 +2,8 @@ create table
 helper_parties (
 uuid uuid default gen_random_uuid() primary key,
 display_name varchar(255) unique not null,
-created_at timestamp default current_timestamp not null
+created_at timestamp default current_timestamp not null,
+modified_at timestamp default current_timestamp not null
 );
 
 alter table helper_parties enable row level security;
@@ -27,7 +28,8 @@ create table
 helper_party_networks (
 uuid uuid default gen_random_uuid() primary key,
 display_name varchar(255) unique not null,
-created_at timestamp default current_timestamp not null
+created_at timestamp default current_timestamp not null,
+modified_at timestamp default current_timestamp not null
 );
 
 alter table helper_party_networks enable row level security;

--- a/server/supabase/seed.sql
+++ b/server/supabase/seed.sql
@@ -1,0 +1,22 @@
+--
+-- Data for Name: helper_parties; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.helper_parties (uuid, display_name, created_at) VALUES ('de218b52-1ec7-4a4d-9bf9-f9070b2c3a93', 'Local test helper 1', '2024-06-05 20:37:32.472191');
+INSERT INTO public.helper_parties (uuid, display_name, created_at) VALUES ('b8848f0f-65c4-499f-82b4-1e3a119ba31e', 'Local test helper 2', '2024-06-05 20:37:45.47656');
+INSERT INTO public.helper_parties (uuid, display_name, created_at) VALUES ('91993b4a-4131-4b9f-a132-d4a5839e3c6c', 'Local test helper 3', '2024-06-05 20:37:53.375326');
+
+
+--
+-- Data for Name: helper_party_networks; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.helper_party_networks (uuid, display_name, size, created_at) VALUES ('a8c892ae-8cee-472f-95f0-e25b1fec9759', 'Local test network', 3, '2024-06-05 20:38:40.956239');
+
+--
+-- Data for Name: helper_party_network_members; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid, created_at) VALUES ('de218b52-1ec7-4a4d-9bf9-f9070b2c3a93', 'a8c892ae-8cee-472f-95f0-e25b1fec9759', '2024-06-05 20:39:01.362579');
+INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid, created_at) VALUES ('b8848f0f-65c4-499f-82b4-1e3a119ba31e', 'a8c892ae-8cee-472f-95f0-e25b1fec9759', '2024-06-05 20:39:10.502079');
+INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid, created_at) VALUES ('91993b4a-4131-4b9f-a132-d4a5839e3c6c', 'a8c892ae-8cee-472f-95f0-e25b1fec9759', '2024-06-05 20:39:24.703602');

--- a/server/supabase/seed.sql
+++ b/server/supabase/seed.sql
@@ -2,21 +2,21 @@
 -- Data for Name: helper_parties; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-INSERT INTO public.helper_parties (uuid, display_name, created_at) VALUES ('de218b52-1ec7-4a4d-9bf9-f9070b2c3a93', 'Local test helper 1', '2024-06-05 20:37:32.472191');
-INSERT INTO public.helper_parties (uuid, display_name, created_at) VALUES ('b8848f0f-65c4-499f-82b4-1e3a119ba31e', 'Local test helper 2', '2024-06-05 20:37:45.47656');
-INSERT INTO public.helper_parties (uuid, display_name, created_at) VALUES ('91993b4a-4131-4b9f-a132-d4a5839e3c6c', 'Local test helper 3', '2024-06-05 20:37:53.375326');
+INSERT INTO public.helper_parties (uuid, display_name) VALUES ('de218b52-1ec7-4a4d-9bf9-f9070b2c3a93', 'Local test helper 1');
+INSERT INTO public.helper_parties (uuid, display_name) VALUES ('b8848f0f-65c4-499f-82b4-1e3a119ba31e', 'Local test helper 2');
+INSERT INTO public.helper_parties (uuid, display_name) VALUES ('91993b4a-4131-4b9f-a132-d4a5839e3c6c', 'Local test helper 3');
 
 
 --
 -- Data for Name: helper_party_networks; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-INSERT INTO public.helper_party_networks (uuid, display_name, created_at) VALUES ('a8c892ae-8cee-472f-95f0-e25b1fec9759', 'Local test network', '2024-06-05 20:38:40.956239');
+INSERT INTO public.helper_party_networks (uuid, display_name) VALUES ('a8c892ae-8cee-472f-95f0-e25b1fec9759', 'Local test network');
 
 --
 -- Data for Name: helper_party_network_members; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid, created_at) VALUES ('de218b52-1ec7-4a4d-9bf9-f9070b2c3a93', 'a8c892ae-8cee-472f-95f0-e25b1fec9759', '2024-06-05 20:39:01.362579');
-INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid, created_at) VALUES ('b8848f0f-65c4-499f-82b4-1e3a119ba31e', 'a8c892ae-8cee-472f-95f0-e25b1fec9759', '2024-06-05 20:39:10.502079');
-INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid, created_at) VALUES ('91993b4a-4131-4b9f-a132-d4a5839e3c6c', 'a8c892ae-8cee-472f-95f0-e25b1fec9759', '2024-06-05 20:39:24.703602');
+INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid) VALUES ('de218b52-1ec7-4a4d-9bf9-f9070b2c3a93', 'a8c892ae-8cee-472f-95f0-e25b1fec9759');
+INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid) VALUES ('b8848f0f-65c4-499f-82b4-1e3a119ba31e', 'a8c892ae-8cee-472f-95f0-e25b1fec9759');
+INSERT INTO public.helper_party_network_members (helper_party_uuid, helper_party_network_uuid) VALUES ('91993b4a-4131-4b9f-a132-d4a5839e3c6c', 'a8c892ae-8cee-472f-95f0-e25b1fec9759');

--- a/server/supabase/seed.sql
+++ b/server/supabase/seed.sql
@@ -11,7 +11,7 @@ INSERT INTO public.helper_parties (uuid, display_name, created_at) VALUES ('9199
 -- Data for Name: helper_party_networks; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-INSERT INTO public.helper_party_networks (uuid, display_name, size, created_at) VALUES ('a8c892ae-8cee-472f-95f0-e25b1fec9759', 'Local test network', 3, '2024-06-05 20:38:40.956239');
+INSERT INTO public.helper_party_networks (uuid, display_name, created_at) VALUES ('a8c892ae-8cee-472f-95f0-e25b1fec9759', 'Local test network', '2024-06-05 20:38:40.956239');
 
 --
 -- Data for Name: helper_party_network_members; Type: TABLE DATA; Schema: public; Owner: postgres


### PR DESCRIPTION
this creates 3 new tables:
1. helper_parties
2. helper_party_networks
3. helper_party_network_members (a join table for 1 and 2)

changes to `server/data/supabaseTypes.ts` are autogenerated, and the seed data is just for testing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new tables for managing helper parties, networks, and their members.
  - Implemented row-level security and access policies for these new tables to ensure data protection and controlled access by authenticated users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->