### PR TITLE
[BUG FIX] fix bug where form didn't include off Switches

### DIFF
--- a/server/app/query/create/page.tsx
+++ b/server/app/query/create/page.tsx
@@ -349,7 +349,6 @@ function IPAForm({
           <Switch
             checked={stallDetectionEnabled}
             onChange={setStallDetectionEnabled}
-            name="stall_detection"
             className={`${
               stallDetectionEnabled ? "bg-blue-600" : "bg-gray-200"
             } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
@@ -360,6 +359,12 @@ function IPAForm({
               } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
             />
           </Switch>
+          {/* Hidden input to ensure the field is always included in the form data */}
+          <input
+            type="hidden"
+            name="stall_detection"
+            value={stallDetectionEnabled.toString()}
+          />
         </div>
       </div>
 
@@ -371,7 +376,6 @@ function IPAForm({
           <Switch
             checked={multiThreadingEnabled}
             onChange={setMultiThreadingEnabled}
-            name="multi_threading"
             className={`${
               multiThreadingEnabled ? "bg-blue-600" : "bg-gray-200"
             } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
@@ -382,6 +386,11 @@ function IPAForm({
               } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
             />
           </Switch>
+          <input
+            type="hidden"
+            name="multi_threading"
+            value={multiThreadingEnabled.toString()}
+          />
         </div>
       </div>
 
@@ -393,7 +402,6 @@ function IPAForm({
           <Switch
             checked={disableMetricsEnabled}
             onChange={setDisableMetricsEnabled}
-            name="disable_metrics"
             className={`${
               disableMetricsEnabled ? "bg-blue-600" : "bg-gray-200"
             } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
@@ -404,6 +412,11 @@ function IPAForm({
               } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
             />
           </Switch>
+          <input
+            type="hidden"
+            name="disable_metrics"
+            value={disableMetricsEnabled.toString()}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
turns out the `Switch` element by default sets the value to "on" if it's on, and removes it entirely from the form if it's off. The API expects a bool, so we override it here.

as an aside, this makes a good case for adding tests, even for some of the front end flows. moving it up my prioritization list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hidden input fields for `stall_detection`, `multi_threading`, and `disable_metrics` to ensure these settings are always included in the form data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->