### PR TITLE
migrate all timestamp columns to timestamptz (timezone aware)

### DIFF
--- a/server/data/helper_party_api_key.ts
+++ b/server/data/helper_party_api_key.ts
@@ -8,6 +8,8 @@ export async function validateApiKey(
   key: string,
 ): Promise<boolean> {
   const supabase = await createSupabaseServiceClient();
+  // toISOString() always and only returns UTC timestamps
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
   const currentTimestamp = new Date().toISOString();
   const { data, error } = await supabase
     .from("helper_party_api_keys")

--- a/server/supabase/migrations/20240621172426_timestamptz.sql
+++ b/server/supabase/migrations/20240621172426_timestamptz.sql
@@ -1,0 +1,17 @@
+alter table queries alter created_at type timestamptz using created_at at time zone 'utc';
+alter table queries alter started_at type timestamptz using started_at at time zone 'utc';
+alter table queries alter ended_at type timestamptz using ended_at at time zone 'utc';
+
+alter table helper_parties alter created_at type timestamptz using created_at at time zone 'utc';
+alter table helper_parties alter modified_at type timestamptz using modified_at at time zone 'utc';
+
+alter table helper_party_networks alter created_at type timestamptz using created_at at time zone 'utc';
+alter table helper_party_networks alter modified_at type timestamptz using modified_at at time zone 'utc';
+
+alter table helper_party_network_members alter created_at type timestamptz using created_at at time zone 'utc';
+
+alter table helper_party_query_status_updates alter started_at type timestamptz using started_at at time zone 'utc';
+
+alter table helper_party_api_keys alter created_at type timestamptz using created_at at time zone 'utc';
+alter table helper_party_api_keys alter expires_at type timestamptz using expires_at at time zone 'utc';
+alter table helper_party_api_keys alter modified_at type timestamptz using modified_at at time zone 'utc';


### PR DESCRIPTION
this alters the db so that all columns use the timezone aware version of timestamp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comment explaining the use of `toISOString()` for UTC timestamps.

- **Chores**
  - Updated database schema to use `timestamptz` for timestamp fields and adjusted them to UTC time zone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->