### PR TITLE
helper domains also added to /etc/hosts in readme for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="<ANON_KEY>"
 **Add local draft.test domain to `/etc/hosts`:**
 
 ```
-echo "#draft local domains\n127.0.0.1 draft.test\n127.0.0.1 sidecar0.draft.test\n127.0.0.1 sidecar1.draft.test\n127.0.0.1 sidecar2.draft.test\n127.0.0.1 sidecar3.draft.test" | sudo tee -a /etc/hosts
+echo "#draft local domains\n127.0.0.1 draft.test\n127.0.0.1 sidecar0.draft.test\n127.0.0.1 sidecar1.draft.test\n127.0.0.1 sidecar2.draft.test\n127.0.0.1 sidecar3.draft.test \n127.0.0.1 helper1.draft.test\n127.0.0.1 helper2.draft.test\n127.0.0.1 helper3.draft.test"" | sudo tee -a /etc/hosts
 ```
 
 **make local certs**

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="<ANON_KEY>"
 **Add local draft.test domain to `/etc/hosts`:**
 
 ```
-echo "#draft local domains\n127.0.0.1 draft.test\n127.0.0.1 sidecar0.draft.test\n127.0.0.1 sidecar1.draft.test\n127.0.0.1 sidecar2.draft.test\n127.0.0.1 sidecar3.draft.test \n127.0.0.1 helper1.draft.test\n127.0.0.1 helper2.draft.test\n127.0.0.1 helper3.draft.test"" | sudo tee -a /etc/hosts
+echo "#draft local domains\n127.0.0.1 draft.test\n127.0.0.1 sidecar0.draft.test\n127.0.0.1 sidecar1.draft.test\n127.0.0.1 sidecar2.draft.test\n127.0.0.1 sidecar3.draft.test \n127.0.0.1 helper1.draft.test\n127.0.0.1 helper2.draft.test\n127.0.0.1 helper3.draft.test" | sudo tee -a /etc/hosts
 ```
 
 **make local certs**


### PR DESCRIPTION
`network.conf` uses `url=helper<n>.draft.test`, so these are also needed in `/etc/hosts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README with new instructions for adding additional local domains (`helper1.draft.test`, `helper2.draft.test`, and `helper3.draft.test`) to the `/etc/hosts` file for draft testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->