### PR TITLE
Logging improvements

### DIFF
--- a/server/app/query/servers.tsx
+++ b/server/app/query/servers.tsx
@@ -160,9 +160,9 @@ export class RemoteServer {
           );
 
           return [
-            ...prevLogs.slice(-maxNumLogs, lastPreviousLogIndex),
+            ...prevLogs.slice(-maxNumLogs, lastPreviousLogIndex + 1),
             newLog,
-            ...prevLogs.slice(lastPreviousLogIndex),
+            ...prevLogs.slice(lastPreviousLogIndex - 1),
           ];
         }
       });

--- a/server/app/query/servers.tsx
+++ b/server/app/query/servers.tsx
@@ -87,6 +87,10 @@ export class RemoteServer {
     throw new Error("Not Implemented");
   }
 
+  logURL(id: string): URL {
+    return new URL(`/start/${id}/log-file`, this.baseURL);
+  }
+
   logsWebSocketURL(id: string): URL {
     const webSocketURL = new URL(`/ws/logs/${id}`, this.baseURL);
     webSocketURL.protocol = "wss";

--- a/server/app/query/view/[id]/components.tsx
+++ b/server/app/query/view/[id]/components.tsx
@@ -88,31 +88,45 @@ export function LogViewer({
   return (
     <div
       className={clsx(
-        "w-full bg-white dark:bg-slate-950 overflow-y-scroll max-h-96 text-start indent-[-128px] pl-32 text-wrap",
+        "w-full bg-white dark:bg-slate-950 overflow-y-scroll max-h-96 text-start text-wrap",
         className,
       )}
     >
       <div className="px-4 py-5 sm:p-6">
-        {logs.map((log, index) => (
+        <dl>
+          {logs.map((log, index) => {
+            const date = new Date(log.timestamp * 1000);
+            return (
+              <div className="flex" key={index}>
+                <dt
+                  className={clsx(
+                    "flex-none w-80 text-slate-900 dark:text-slate-100 text-xs",
+                    sourceCodePro.className,
+                  )}
+                >
+                  {date.toISOString()} | {log.remoteServer.remoteServerNameStr}:
+                </dt>
+                <dd
+                  className={clsx(
+                    "text-slate-900 dark:text-slate-100 text-xs",
+                    sourceCodePro.className,
+                  )}
+                >
+                  {log.logLine}
+                </dd>
+              </div>
+            );
+          })}
           <div
-            key={index}
+            key="last"
             className={clsx(
-              "text-slate-900 dark:text-slate-100 text-xs whitespace-pre-line",
+              "text-slate-900 dark:text-slate-100 text-xs whitespace-pre-line animate-pulse",
               sourceCodePro.className,
             )}
           >
-            {log.logLine}
+            {">_"}
           </div>
-        ))}
-        <div
-          key="last"
-          className={clsx(
-            "text-slate-900 dark:text-slate-100 text-xs whitespace-pre-line animate-pulse",
-            sourceCodePro.className,
-          )}
-        >
-          {">_"}
-        </div>
+        </dl>
       </div>
     </div>
   );

--- a/server/app/query/view/[id]/page.tsx
+++ b/server/app/query/view/[id]/page.tsx
@@ -27,6 +27,7 @@ export default function QueryPage({ params }: { params: { id: string } }) {
   // display controls
   const [logsHidden, setLogsHidden] = useState<boolean>(true);
   const [statsHidden, setStatsHidden] = useState<boolean>(true);
+  const [query, setQuery] = useState<Query | null>(null);
 
   const [logs, setLogs] = useState<ServerLog[]>([]);
   const [statusByRemoteServer, setStatusByRemoteServer] =
@@ -61,6 +62,7 @@ export default function QueryPage({ params }: { params: { id: string } }) {
   useEffect(() => {
     (async () => {
       const query: Query = await getQuery(params.id);
+      setQuery(query);
       let webSockets: WebSocket[] = [];
       // useEffect() gets called twice locally
       // so this prevents the logs from being shown twice
@@ -188,7 +190,48 @@ export default function QueryPage({ params }: { params: { id: string } }) {
             </dl>
           </div>
         </button>
-        {!logsHidden && <LogViewer logs={logs} />}
+        {!logsHidden && (
+          <>
+            <div>
+              <ul
+                role="list"
+                className="divide-y divide-gray-100 dark:divide-gray-900 border-b border-gray-200 dark:border-gray-800"
+              >
+                {Object.values(IPARemoteServers).map(
+                  (remoteServer: RemoteServer) => {
+                    return (
+                      <>
+                        <li className="flex items-center justify-between py-2 pl-4 pr-5 text-sm leading-6">
+                          <div className="flex w-0 flex-1 items-center">
+                            <div className="ml-4 flex min-w-0 flex-1 gap-2">
+                              <span className="truncate font-medium">
+                                {remoteServer.remoteServerNameStr}-{query?.uuid}
+                                .log
+                              </span>
+                            </div>
+                          </div>
+                          {query && (
+                            <div className="ml-4 flex-shrink-0">
+                              <a
+                                href={remoteServer
+                                  .logURL(query.uuid)
+                                  .toString()}
+                                className="font-medium text-indigo-600 hover:text-indigo-500"
+                              >
+                                Download
+                              </a>
+                            </div>
+                          )}
+                        </li>
+                      </>
+                    );
+                  },
+                )}
+              </ul>
+            </div>
+            <LogViewer logs={logs} />
+          </>
+        )}
       </div>
     </>
   );

--- a/server/app/query/view/[id]/page.tsx
+++ b/server/app/query/view/[id]/page.tsx
@@ -62,6 +62,9 @@ export default function QueryPage({ params }: { params: { id: string } }) {
     (async () => {
       const query: Query = await getQuery(params.id);
       let webSockets: WebSocket[] = [];
+      // useEffect() gets called twice locally
+      // so this prevents the logs from being shown twice
+      setLogs([]);
       for (const remoteServer of Object.values(IPARemoteServers)) {
         const loggingWs = remoteServer.openLogSocket(query.uuid, setLogs);
         const statusWs = remoteServer.openStatusSocket(

--- a/sidecar/app/query/base.py
+++ b/sidecar/app/query/base.py
@@ -43,7 +43,7 @@ class Query:
         self._status_dir.mkdir(exist_ok=True)
         self._logger_id = logger.add(
             self.log_file_path,
-            format="{extra[role]}: {message}",
+            serialize=True,
             filter=lambda record: record["extra"].get("task") == self.query_id,
             enqueue=True,
         )


### PR DESCRIPTION
This fixes #45, sorting logs by the timestamp provided by the server.

Addtionally, it addresses #46 allowing for downloading log files from each server.

Finally, it also allows for filtering of displayed logs by each server.

<img width="1364" alt="image" src="https://github.com/private-attribution/draft/assets/982499/ea5af03a-b3c8-4633-8f7b-510fbdc7f6fe">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced timestamp and server name display in log entries.
  - Added checkbox UI elements for selecting remote servers and displaying logs.

- **Improvements**
  - Enhanced log handling and parsing for better clarity and retention.
  - Updated log generation to include URLs for easier access.
  - Improved log formatting with serialization for consistency.

- **Bug Fixes**
  - Fixed issues with logs being shown twice by refining logic in the `kill` function and `useEffect`.

- **API Updates**
  - Added a new endpoint to retrieve log files associated with a query ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->