### PR TITLE
only use root_domain variable for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Once you know these:
 ### Run draft
 
 ```
-draft start-helper-sidecar --identity <identity> --root_domain example.com --config_path config
+draft start-helper-sidecar --identity <identity> --helper_domain helper.example.com --sidecar_domain sidecar.example.com --config_path config
 ```
 
-This will start the sidecar in the background. To confirm, visit `example.com/status`.
+This will start the sidecar in the background. To confirm, visit `sidecar.example.com/status`.
 
 
 ## Local Dev

--- a/ansible/deploy.yaml
+++ b/ansible/deploy.yaml
@@ -23,7 +23,6 @@
         source .venv/bin/activate &&
         draft start-helper-sidecar
         --identity {{ identity }}
-        --root_domain {{ root_domain }}
         --helper_domain {{ helper_domain }}
         --sidecar_domain {{ sidecar_domain }}
         --config_path {{ ansible_env.HOME }}/draft/config

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -5,4 +5,3 @@ ipa-2           identity=2      helper_domain=helper2.ipa-helper.dev    sidecar_
 ipa-3           identity=3      helper_domain=helper3.ipa-helper.dev    sidecar_domain=sidecar3.ipa-helper.dev
 [myhosts:vars]
 ansible_python_interpreter=/usr/bin/python3
-root_domain=ipa-helper.dev

--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -113,7 +113,6 @@
         source .venv/bin/activate &&
         draft start-helper-sidecar
         --identity {{ identity }}
-        --root_domain {{ root_domain }}
         --helper_domain {{ helper_domain }}
         --sidecar_domain {{ sidecar_domain }}
         --config_path {{ ansible_env.HOME }}/draft/config

--- a/etc/start_helper_sidecar.sh
+++ b/etc/start_helper_sidecar.sh
@@ -9,11 +9,10 @@ fi
 
 config_path=$1
 root_path=$2
-root_domain=$3
-helper_domain=$4
-sidecar_domain=$5
-helper_port=$6
-sidecar_port=$7
-identity=$8
+helper_domain=$3
+sidecar_domain=$4
+helper_port=$5
+sidecar_port=$6
+identity=$7
 
-nohup draft run-helper-sidecar --config_path "$config_path" --root_path "$root_path" --root_domain "$root_domain" --helper_domain "$helper_domain" --sidecar_domain "$sidecar_domain" --helper_port "$helper_port" --sidecar_port "$sidecar_port" --identity "$identity" > .draft/logs/helper_sidecar.log 2>&1 & echo $! > $pid_file
+nohup draft run-helper-sidecar --config_path "$config_path" --root_path "$root_path" --helper_domain "$helper_domain" --sidecar_domain "$sidecar_domain" --helper_port "$helper_port" --sidecar_port "$sidecar_port" --identity "$identity" > .draft/logs/helper_sidecar.log 2>&1 & echo $! > $pid_file

--- a/sidecar/cli/cli.py
+++ b/sidecar/cli/cli.py
@@ -77,14 +77,11 @@ def start_helper_sidecar_command(
 # pylint: disable=too-many-arguments
 def start_traefik_command(
     config_path: Path,
-    root_domain: str,
-    helper_domain: str | None,
-    sidecar_domain: str | None,
+    helper_domain: str,
+    sidecar_domain: str,
     helper_port: int,
     sidecar_port: int,
 ):
-    sidecar_domain = sidecar_domain or f"sidecar.{root_domain}"
-    helper_domain = helper_domain or f"helper.{root_domain}"
     env = {
         **os.environ,
         "SIDECAR_DOMAIN": sidecar_domain,
@@ -136,18 +133,16 @@ def start_traefik_local_command(
     show_default=True,
 )
 @click.option("--root_path", type=click_pathlib.Path(), default=None)
-@click.option("--root_domain", type=str, default="ipa-helper.dev")
-@click.option("--helper_domain", type=str, default=None)
-@click.option("--sidecar_domain", type=str, default=None)
+@click.option("--helper_domain", required=True, type=str)
+@click.option("--sidecar_domain", required=True, type=str)
 @click.option("--helper_port", type=int, default=7430)
 @click.option("--sidecar_port", type=int, default=17430)
 @click.option("--identity", required=True, type=int)
 def run_helper_sidecar(
     config_path: Path,
     root_path: Path,
-    root_domain: str,
-    helper_domain: str | None,
-    sidecar_domain: str | None,
+    helper_domain: str,
+    sidecar_domain: str,
     helper_port: int,
     sidecar_port: int,
     identity: int,
@@ -161,7 +156,6 @@ def run_helper_sidecar(
     )
     traefik_command = start_traefik_command(
         config_path=config_path,
-        root_domain=root_domain,
         helper_domain=helper_domain,
         sidecar_domain=sidecar_domain,
         helper_port=helper_port,
@@ -179,16 +173,14 @@ def run_helper_sidecar(
     show_default=True,
 )
 @click.option("--root_path", type=click_pathlib.Path(), default=Path("."))
-@click.option("--root_domain", type=str, default="ipa-helper.dev")
-@click.option("--helper_domain", type=str, default="")
-@click.option("--sidecar_domain", type=str, default="")
+@click.option("--helper_domain", required=True, type=str)
+@click.option("--sidecar_domain", required=True, type=str)
 @click.option("--helper_port", type=int, default=7430)
 @click.option("--sidecar_port", type=int, default=17430)
 @click.option("--identity", required=True, type=int)
 def start_helper_sidecar(
     config_path: Path,
     root_path: Path,
-    root_domain: str,
     helper_domain: str,
     sidecar_domain: str,
     helper_port: int,
@@ -205,8 +197,10 @@ def start_helper_sidecar(
     script_path = root_path / Path("etc/start_helper_sidecar.sh")
 
     start_command = Command(
-        cmd=f"{script_path} {config_path} {root_path} {root_domain} "
-        f"{helper_domain} {sidecar_domain} {helper_port} {sidecar_port} {identity}",
+        cmd=(
+            f"{script_path} {config_path} {root_path} {helper_domain} {sidecar_domain} "
+            f"{helper_port} {sidecar_port} {identity}"
+        ),
     )
     start_command.run_blocking_no_output_capture()
     print("draft helper_sidecar started")


### PR DESCRIPTION
I'm preparing to do some work on deployments, and I realized this variable doesn't actually make sense outside of local dev. When starting a helper, we should explicitly set the helper and sidecar domains.

This cleans that up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README with new command parameters and confirmation URL for starting the sidecar service.

- **Chores**
  - Removed `--root_domain` argument from Ansible configuration files (`deploy.yaml` and `provision.yaml`).
  - Removed `root_domain=ipa-helper.dev` declaration from `ansible/inventory.ini`.

- **Refactor**
  - Adjusted variable assignments in `start_helper_sidecar.sh` for domains, ports, and identity.

- **Bug Fixes**
  - Updated `cli.py` to require explicit `helper_domain` and `sidecar_domain` parameters, removing default assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->