### PR TITLE
Status events

### DIFF
--- a/server/app/query/view/[id]/components.tsx
+++ b/server/app/query/view/[id]/components.tsx
@@ -86,7 +86,7 @@ export function RunTimePill({
     if (startTime === null) {
       setRunTime(null);
     } else {
-      if (endTime !== null && startTime !== null) {
+      if (endTime !== null) {
         setRunTime(endTime - startTime);
       } else {
         let newIntervalId = setInterval(() => {

--- a/server/app/query/view/[id]/components.tsx
+++ b/server/app/query/view/[id]/components.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState, useRef } from "react";
 import { Source_Code_Pro } from "next/font/google";
 import clsx from "clsx";
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
@@ -65,12 +66,34 @@ function secondsToTime(e: number) {
 
 export function RunTimePill({
   status,
-  runTime,
+  startTime,
+  endTime,
 }: {
   status: Status;
-  runTime: number | null;
+  startTime: number | null;
+  endTime: number | null;
 }) {
+  const [runTime, setRunTime] = useState<number>(0);
   const runTimeStr = runTime ? secondsToTime(runTime) : "N/A";
+  const intervalId = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (startTime !== null) {
+      if (endTime !== null && startTime !== null) {
+        setRunTime(endTime - startTime);
+      } else {
+        if (intervalId.current !== null) {
+          clearTimeout(intervalId.current);
+        }
+
+        let newIntervalId = setInterval(() => {
+          setRunTime(Date.now() / 1000 - startTime);
+        }, 1000);
+        intervalId.current = newIntervalId;
+      }
+    }
+  }, [startTime, endTime]);
+
   return (
     <div className={clsx(`rounded-full px-2`, StatusClassNameMixins[status])}>
       {runTimeStr}

--- a/server/app/query/view/[id]/components.tsx
+++ b/server/app/query/view/[id]/components.tsx
@@ -73,19 +73,22 @@ export function RunTimePill({
   startTime: number | null;
   endTime: number | null;
 }) {
-  const [runTime, setRunTime] = useState<number>(0);
+  const [runTime, setRunTime] = useState<number | null>(null);
   const runTimeStr = runTime ? secondsToTime(runTime) : "N/A";
   const intervalId = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (startTime !== null) {
+    if (intervalId.current !== null) {
+      // any time startTime or endTime change, we remove the old setInterval
+      // which runs the timer. if a new one is needed, it's created.
+      clearTimeout(intervalId.current);
+    }
+    if (startTime === null) {
+      setRunTime(null);
+    } else {
       if (endTime !== null && startTime !== null) {
         setRunTime(endTime - startTime);
       } else {
-        if (intervalId.current !== null) {
-          clearTimeout(intervalId.current);
-        }
-
         let newIntervalId = setInterval(() => {
           setRunTime(Date.now() / 1000 - startTime);
         }, 1000);

--- a/server/app/query/view/[id]/page.tsx
+++ b/server/app/query/view/[id]/page.tsx
@@ -16,10 +16,12 @@ import {
   IPARemoteServers, //hack until the queryId is stored in a DB
   StatusByRemoteServer,
   StatsByRemoteServer,
-  RunTimeByRemoteServer,
+  StartTimeByRemoteServer,
+  EndTimeByRemoteServer,
   initialStatusByRemoteServer,
   initialStatsByRemoteServer,
-  initialRunTimeByRemoteServer,
+  initialStartTimeByRemoteServer,
+  initialEndTimeByRemoteServer,
 } from "@/app/query/servers";
 import { StatsComponent } from "@/app/query/view/[id]/charts";
 import { JSONSafeParse } from "@/app/utils";
@@ -48,8 +50,10 @@ export default function QueryPage({ params }: { params: { id: string } }) {
     useState<StatusByRemoteServer>(initialStatusByRemoteServer);
   const [statsByRemoteServer, setStatsByRemoteServer] =
     useState<StatsByRemoteServer>(initialStatsByRemoteServer);
-  const [runTimeByRemoteServer, setRunTimeByRemoteServer] =
-    useState<RunTimeByRemoteServer>(initialRunTimeByRemoteServer);
+  const [startTimeByRemoteServer, setStartTimeByRemoteServer] =
+    useState<StartTimeByRemoteServer>(initialStartTimeByRemoteServer);
+  const [endTimeByRemoteServer, setEndTimeByRemoteServer] =
+    useState<EndTimeByRemoteServer>(initialEndTimeByRemoteServer);
 
   function flipLogsHidden() {
     setLogsHidden(!logsHidden);
@@ -108,11 +112,12 @@ export default function QueryPage({ params }: { params: { id: string } }) {
         const statusWs = remoteServer.openStatusSocket(
           query.uuid,
           setStatusByRemoteServer,
+          setStartTimeByRemoteServer,
+          setEndTimeByRemoteServer,
         );
         const statsWs = remoteServer.openStatsSocket(
           query.uuid,
           setStatsByRemoteServer,
-          setRunTimeByRemoteServer,
         );
         webSockets = [...webSockets, loggingWs, statusWs, statsWs];
       }
@@ -212,8 +217,11 @@ export default function QueryPage({ params }: { params: { id: string } }) {
             <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
               {Object.values(IPARemoteServers).map(
                 (remoteServer: RemoteServer) => {
-                  const runTime =
-                    runTimeByRemoteServer[remoteServer.remoteServerName];
+                  const startTime =
+                    startTimeByRemoteServer[remoteServer.remoteServerName];
+                  const endTime =
+                    endTimeByRemoteServer[remoteServer.remoteServerName];
+
                   const status =
                     statusByRemoteServer[remoteServer.remoteServerName] ??
                     Status.UNKNOWN;
@@ -227,7 +235,11 @@ export default function QueryPage({ params }: { params: { id: string } }) {
                         {remoteServer.toString()} Run Time
                       </dt>
                       <dd>
-                        <RunTimePill status={status} runTime={runTime} />
+                        <RunTimePill
+                          status={status}
+                          startTime={startTime}
+                          endTime={endTime}
+                        />
                       </dd>
                     </div>
                   );

--- a/sidecar/app/routes/websockets.py
+++ b/sidecar/app/routes/websockets.py
@@ -34,15 +34,17 @@ async def status_websocket(websocket: WebSocket, query_id: str):
     async with use_websocket(websocket) as websocket:
         if query is None:
             logger.warning(f"{query_id=} Status: {Status.NOT_FOUND.name}")
-            await websocket.send_json({"status": Status.NOT_FOUND.name})
+            await websocket.send_json(
+                {"status": Status.NOT_FOUND.name, "start_time": time.time()}
+            )
         else:
             while query.running:
                 logger.debug(f"{query_id=} Status: {query.status.name}")
-                await websocket.send_json({"status": query.status.name})
+                await websocket.send_json(query.status_event_json)
                 await asyncio.sleep(1)
 
             logger.debug(f"{query_id=} Status: {query.status.name}")
-            await websocket.send_json({"status": query.status.name})
+            await websocket.send_json(query.status_event_json)
 
 
 @router.websocket("/logs/{query_id}")
@@ -81,7 +83,6 @@ async def stats_websocket(websocket: WebSocket, query_id: str):
         while query.running:
             await websocket.send_json(
                 {
-                    "run_time": query.run_time,
                     "cpu_percent": query.cpu_usage_percent,
                     "memory_rss_usage": query.memory_rss_usage,
                     "timestamp": time.time(),


### PR DESCRIPTION
This updates the sidecar to store the entire status history of a query, instead of just the current status. It also includes a timestamp. With that timestamp, we're then able to simply update the run time based on when the current status started, and in the case where it's complete/finished/crashed, it shows the difference between start and end time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced start and end time tracking for remote servers to provide more detailed runtime data.

- **Enhancements**
  - Improved the runtime calculation by displaying dynamic runtime based on start and end times.

- **Bug Fixes**
  - Updated socket handling to correctly manage start and end times, ensuring accurate status updates.

- **Backend Improvements**
  - Added status change history tracking and enhanced status event handling for more accurate server status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->