### PR TITLE
add .log at the end of log files

### DIFF
--- a/sidecar/app/query/base.py
+++ b/sidecar/app/query/base.py
@@ -24,7 +24,7 @@ def status_file_path(query_id: str) -> Path:
 
 def log_file_path(query_id: str) -> Path:
     settings = get_settings()
-    return settings.log_dir_path / Path(query_id)
+    return settings.log_dir_path / Path(f"{query_id}.log")
 
 
 @dataclass


### PR DESCRIPTION
This got dropped recently, so this fixes it. I'll also hop on each machine to add .log where it's missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced log file naming convention by appending the `.log` extension to generated log files for improved file identification and management.
  
- **Bug Fixes**
	- Standardized log file output format to align with typical conventions, ensuring consistency in file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->