### PR TITLE
bump ansible to install rust 1.80

### DIFF
--- a/sidecar/ansible/provision.yaml
+++ b/sidecar/ansible/provision.yaml
@@ -30,8 +30,8 @@
         executable: /bin/bash
       when: rustup_installed.rc != 0
 
-    - name: Update Rust to 1.77
-      command: rustup update 1.77.0
+    - name: Update Rust to 1.80
+      command: rustup update 1.80.0
 
     - name: Check if Git is installed
       command: git --version

--- a/sidecar/ansible/provision.yaml
+++ b/sidecar/ansible/provision.yaml
@@ -33,6 +33,9 @@
     - name: Update Rust to 1.80
       command: rustup update 1.80.0
 
+    - name: Set default to 1.80
+      command: rustup default 1.80.0
+
     - name: Check if Git is installed
       command: git --version
       register: git_installed


### PR DESCRIPTION
IPA requires rust 1.80 now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Upgraded the Rust installation to version 1.80.0, introducing potential enhancements and new features.

- **Bug Fixes**
    - Updated the installation command to ensure compatibility and access to the latest improvements in Rust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->