### PR TITLE
Adding toggle that enables reveal based aggregation

### DIFF
--- a/server/app/query/create/page.tsx
+++ b/server/app/query/create/page.tsx
@@ -148,7 +148,8 @@ function IPAForm({
   const [stallDetectionEnabled, setStallDetectionEnabled] = useState(true);
   const [multiThreadingEnabled, setMultiThreadingEnabled] = useState(true);
   const [disableMetricsEnabled, setDisableMetricsEnabled] = useState(false);
-  const [revealAggregationEnabled, setRevealAggregationEnabled] = useState(false);
+  const [revealAggregationEnabled, setRevealAggregationEnabled] =
+    useState(false);
   const disableBranch = commitSpecifier != CommitSpecifier.BRANCH;
   const disableCommitHash = commitSpecifier != CommitSpecifier.COMMIT_HASH;
   const filteredCommitHashes =

--- a/server/app/query/create/page.tsx
+++ b/server/app/query/create/page.tsx
@@ -148,6 +148,7 @@ function IPAForm({
   const [stallDetectionEnabled, setStallDetectionEnabled] = useState(true);
   const [multiThreadingEnabled, setMultiThreadingEnabled] = useState(true);
   const [disableMetricsEnabled, setDisableMetricsEnabled] = useState(false);
+  const [revealAggregationEnabled, setRevealAggregationEnabled] = useState(false);
   const disableBranch = commitSpecifier != CommitSpecifier.BRANCH;
   const disableCommitHash = commitSpecifier != CommitSpecifier.COMMIT_HASH;
   const filteredCommitHashes =
@@ -431,6 +432,32 @@ function IPAForm({
             type="hidden"
             name="disable_metrics"
             value={disableMetricsEnabled.toString()}
+          />
+        </div>
+      </div>
+
+      <div className="items-center pt-4">
+        <div className="block text-sm font-medium leading-6 text-gray-900">
+          Use Breakdown Reveal Aggregation
+        </div>
+        <div className="block pt-1 text-sm font-medium leading-6 text-gray-900">
+          <Switch
+            checked={revealAggregationEnabled}
+            onChange={setRevealAggregationEnabled}
+            className={`${
+              revealAggregationEnabled ? "bg-blue-600" : "bg-gray-200"
+            } relative inline-flex size-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+          >
+            <span
+              className={`${
+                revealAggregationEnabled ? "translate-x-6" : "translate-x-1"
+              } inline-block size-4 rounded-full bg-white transition-transform`}
+            />
+          </Switch>
+          <input
+            type="hidden"
+            name="reveal_aggregation"
+            value={revealAggregationEnabled.toString()}
           />
         </div>
       </div>

--- a/sidecar/app/query/ipa.py
+++ b/sidecar/app/query/ipa.py
@@ -166,6 +166,7 @@ class IPAHelperCompileStep(LoggerOutputCommandStep):
     stall_detection: bool
     multi_threading: bool
     disable_metrics: bool
+    reveal_aggregation: bool
     logger: loguru.Logger = field(repr=False)
     status: ClassVar[Status] = Status.COMPILING
 
@@ -176,6 +177,7 @@ class IPAHelperCompileStep(LoggerOutputCommandStep):
         stall_detection = query.stall_detection
         multi_threading = query.multi_threading
         disable_metrics = query.disable_metrics
+        reveal_aggregation = query.reveal_aggregation
         return cls(
             manifest_path=manifest_path,
             target_path=query.paths.target_path,
@@ -183,6 +185,7 @@ class IPAHelperCompileStep(LoggerOutputCommandStep):
             stall_detection=stall_detection,
             multi_threading=multi_threading,
             disable_metrics=disable_metrics,
+            reveal_aggregation=reveal_aggregation,
             logger=query.logger,
         )
 
@@ -192,6 +195,7 @@ class IPAHelperCompileStep(LoggerOutputCommandStep):
             f'--features="web-app real-world-infra {self.gate_type}'
             f"{' stall-detection' if self.stall_detection else ''}"
             f"{' multi-threading' if self.multi_threading else ''}"
+            f"{' reveal-aggregation' if self.reveal_aggregation else ''}"
             f"{' disable-metrics' if self.disable_metrics else ''}\" "
             f"--no-default-features --target-dir={self.target_path} "
             f"--release",
@@ -410,6 +414,7 @@ class IPAHelperQuery(IPAQuery):
     stall_detection: bool
     multi_threading: bool
     disable_metrics: bool
+    reveal_aggregation: bool
 
     step_classes: ClassVar[list[type[Step]]] = [
         IPACloneStep,

--- a/sidecar/app/query/ipa.py
+++ b/sidecar/app/query/ipa.py
@@ -158,6 +158,7 @@ class IPACorrdinatorCompileStep(LoggerOutputCommandStep):
         )
 
 
+# pylint: disable=R0902
 @dataclass(kw_only=True)
 class IPAHelperCompileStep(LoggerOutputCommandStep):
     manifest_path: Path

--- a/sidecar/app/routes/start.py
+++ b/sidecar/app/routes/start.py
@@ -69,6 +69,7 @@ def start_ipa_helper(
     stall_detection: Annotated[bool, Form()],
     multi_threading: Annotated[bool, Form()],
     disable_metrics: Annotated[bool, Form()],
+    reveal_aggregation: Annotated[bool, Form()],
     background_tasks: BackgroundTasks,
     request: Request,
 ):
@@ -88,6 +89,7 @@ def start_ipa_helper(
         f"{'_stall-detection' if stall_detection else ''}"
         f"{'_multi-threading' if multi_threading else ''}"
         f"{'_disable-metrics' if disable_metrics else ''}"
+        f"{'_reveal-aggregation' if reveal_aggregation else ''}"
     )
 
     paths = Paths(
@@ -103,6 +105,7 @@ def start_ipa_helper(
         stall_detection=stall_detection,
         multi_threading=multi_threading,
         disable_metrics=disable_metrics,
+        reveal_aggregation=reveal_aggregation,
         port=settings.helper_port,
     )
     background_tasks.add_task(query_manager.run_query, query)

--- a/sidecar/tests/app/routes/test_start.py
+++ b/sidecar/tests/app/routes/test_start.py
@@ -67,6 +67,7 @@ def test_start_ipa_helper(mock_role):
                     "stall_detection": True,
                     "multi_threading": True,
                     "disable_metrics": True,
+                    "reveal_aggregation": True,
                 },
             )
             assert response.status_code == 200
@@ -87,6 +88,7 @@ def test_start_ipa_helper_as_coordinator(mock_role):
                         "stall_detection": True,
                         "multi_threading": True,
                         "disable_metrics": True,
+                        "reveal_aggregation": True,
                     },
                 )
 


### PR DESCRIPTION
Tested locally with branch containing https://github.com/private-attribution/ipa/pull/1172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a toggle for the "Breakdown Reveal Aggregation" feature in the IPA form, enhancing user control over data submission.
	- Updated backend functionality to support the new reveal aggregation option, allowing for additional configuration flexibility.

- **Bug Fixes**
	- Improved handling of the reveal aggregation state across various components to ensure correct functionality.

- **Tests**
	- Expanded test cases to include the new "reveal aggregation" parameter, enhancing the testing framework's ability to verify related functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->