### PR TITLE
preserve helper logs on bounce

### DIFF
--- a/etc/start_helper_sidecar.sh
+++ b/etc/start_helper_sidecar.sh
@@ -15,4 +15,5 @@ helper_port=$5
 sidecar_port=$6
 identity=$7
 
-nohup draft run-helper-sidecar --config_path "$config_path" --root_path "$root_path" --helper_domain "$helper_domain" --sidecar_domain "$sidecar_domain" --helper_port "$helper_port" --sidecar_port "$sidecar_port" --identity "$identity" > .draft/logs/helper_sidecar.log 2>&1 & echo $! > $pid_file
+log_file=".draft/logs/helper_sidecar_$(date "+%Y-%m-%d_%H-%M-%S").log"
+nohup draft run-helper-sidecar --config_path "$config_path" --root_path "$root_path" --helper_domain "$helper_domain" --sidecar_domain "$sidecar_domain" --helper_port "$helper_port" --sidecar_port "$sidecar_port" --identity "$identity" > "$log_file" 2>&1 & echo $! > $pid_file

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,7 +17,7 @@
         "chartjs-adapter-spacetime": "^1.0.1",
         "clsx": "^2.0.0",
         "haikunator": "^2.1.2",
-        "next": "^14.2.11",
+        "next": "=14.2.11",
         "octokit": "^3.1.2",
         "pm2": "^5.4.1",
         "react": "^18",

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,7 @@
     "chartjs-adapter-spacetime": "^1.0.1",
     "clsx": "^2.0.0",
     "haikunator": "^2.1.2",
-    "next": "14.2.11",
+    "next": "=14.2.11",
     "octokit": "^3.1.2",
     "pm2": "^5.4.1",
     "react": "^18",

--- a/sidecar/app/routes/start.py
+++ b/sidecar/app/routes/start.py
@@ -61,6 +61,8 @@ def demo_logger(
     return {"message": "Process started successfully", "query_id": query_id}
 
 
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @router.post("/ipa-helper/{query_id}")
 def start_ipa_helper(
     query_id: str,
@@ -73,7 +75,6 @@ def start_ipa_helper(
     background_tasks: BackgroundTasks,
     request: Request,
 ):
-    # pylint: disable=too-many-arguments
     query_manager = request.app.state.QUERY_MANAGER
     check_capacity(query_manager)
 
@@ -153,6 +154,8 @@ def get_ipa_helper_log_file(
     )
 
 
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @router.post("/ipa-query/{query_id}")
 def start_ipa_query(
     query_id: str,
@@ -165,7 +168,6 @@ def start_ipa_query(
     background_tasks: BackgroundTasks,
     request: Request,
 ):
-    # pylint: disable=too-many-arguments
     query_manager = request.app.state.QUERY_MANAGER
     check_capacity(query_manager)
 

--- a/sidecar/cli/cli.py
+++ b/sidecar/cli/cli.py
@@ -124,7 +124,7 @@ def start_traefik_local_command(
     return Command(cmd=cmd, env=env)
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @cli.command
 @click.option(
     "--config_path",
@@ -164,7 +164,7 @@ def run_helper_sidecar(
     start_commands_parallel([sidecar_command, traefik_command])
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @cli.command
 @click.option(
     "--config_path",


### PR DESCRIPTION
adds a timestamp to the log file that the draft process writes to, so that it's not overwritten when we restart draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logging functionality for the helper sidecar command, ensuring unique timestamped log files for each execution.
- **Chores**
	- Updated the `next` package version specification to an exact version, preventing automatic updates.
- **Documentation**
	- Enhanced comments for code quality management in several functions, clarifying pylint directives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->