### PR TITLE
check to make sure helpers need to be killed before sending kill signal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ py-modules = ["sidecar",]
 profile = "black"
 py_version=39
 skip_glob=["server"]
+extra_standard_library = ["tomllib"]
+
 
 [tool.pylint.format]
 max-line-length = "88"

--- a/sidecar/app/helpers.py
+++ b/sidecar/app/helpers.py
@@ -55,7 +55,7 @@ class Helper:
 
     def get_current_query_status(self, query_id: str) -> Status:
         try:
-            r = httpx.get(self.query_kill_url(query_id))
+            r = httpx.get(self.query_status_url(query_id))
         except httpx.RequestError:
             return Status.UNKNOWN
         try:

--- a/sidecar/app/helpers.py
+++ b/sidecar/app/helpers.py
@@ -1,11 +1,15 @@
+import tomllib
 from dataclasses import dataclass
 from enum import IntEnum
+from json import JSONDecodeError
 from pathlib import Path
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
-import tomllib
+import httpx
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.x509 import load_pem_x509_certificate
+
+from .query.step import Status
 
 
 class Role(IntEnum):
@@ -21,6 +25,67 @@ class Helper:
     helper_url: ParseResult
     sidecar_url: ParseResult
     public_key: EllipticCurvePublicKey
+
+    def query_status_url(self, query_id: str) -> str:
+        return str(
+            urlunparse(
+                self.sidecar_url._replace(
+                    scheme="https", path=f"/start/{query_id}/status"
+                ),
+            )
+        )
+
+    def query_finish_url(self, query_id: str) -> str:
+        return str(
+            urlunparse(
+                self.sidecar_url._replace(
+                    scheme="https", path=f"/stop/finish/{query_id}"
+                ),
+            )
+        )
+
+    def query_kill_url(self, query_id: str) -> str:
+        return str(
+            urlunparse(
+                self.sidecar_url._replace(
+                    scheme="https", path=f"/stop/kill/{query_id}"
+                ),
+            )
+        )
+
+    def get_current_query_status(self, query_id: str) -> Status:
+        try:
+            r = httpx.get(self.query_kill_url(query_id))
+        except httpx.RequestError:
+            return Status.UNKNOWN
+        try:
+            j = r.json()
+        except JSONDecodeError:
+            return Status.UNKNOWN
+
+        return Status.from_json(j)
+
+    def kill_query(self, query_id: str) -> str:
+        status = self.get_current_query_status(query_id)
+        if status >= Status.COMPLETE:
+            return (
+                f"not sending kill signal. helper {self.role} "
+                f"already has status {status}"
+            )
+        r = httpx.post(self.query_kill_url(query_id))
+        return f"sent kill signal for query({query_id}) to helper {self.role}: {r.text}"
+
+    def finish_query(self, query_id: str) -> str:
+        status = self.get_current_query_status(query_id)
+        if status >= Status.COMPLETE:
+            return (
+                f"not sending finish signal. helper {self.role} "
+                f"already has status {status}"
+            )
+        r = httpx.post(self.query_finish_url(query_id))
+        return (
+            f"sent finish signal for query({query_id}) to helper {self.role}: {r.text}"
+        )
 
 
 def load_helpers_from_network_config(network_config_path: Path) -> dict[Role, Helper]:

--- a/sidecar/app/query/status.py
+++ b/sidecar/app/query/status.py
@@ -25,7 +25,7 @@ class Status(IntEnum):
         status_str = response.get("status", "")
         try:
             return cls[status_str]
-        except ValueError:
+        except KeyError:
             return cls.UNKNOWN
 
 

--- a/sidecar/app/query/status.py
+++ b/sidecar/app/query/status.py
@@ -20,6 +20,14 @@ class Status(IntEnum):
     KILLED = auto()
     CRASHED = auto()
 
+    @classmethod
+    def from_json(cls, response: dict[str, str]):
+        status_str = response.get("status", "")
+        try:
+            return cls[status_str]
+        except ValueError:
+            return cls.UNKNOWN
+
 
 StatusChangeEvent = NamedTuple(
     "StatusChangeEvent", [("status", Status), ("timestamp", float)]

--- a/sidecar/app/settings.py
+++ b/sidecar/app/settings.py
@@ -63,6 +63,10 @@ class Settings(BaseSettings):
         return self._helpers
 
     @property
+    def other_helpers(self) -> list[Helper]:
+        return [helper for helper in self._helpers.values() if helper.role != self.role]
+
+    @property
     def status_dir_path(self) -> Path:
         return self.root_path / Path("status")
 

--- a/sidecar/tests/app/query/test_status.py
+++ b/sidecar/tests/app/query/test_status.py
@@ -115,17 +115,15 @@ def test_status_history_status_event_json(
     }
 
 
-def test_status_from_json():
-    # matching string
-    status = Status.from_json({"status": "STARTING"})
-    assert status == Status.STARTING
-    status = Status.from_json({"status": "UNKNOWN"})
-    assert status == Status.UNKNOWN
-
-    # non-mathcing string
-    status = Status.from_json({"status": "not-a-status"})
-    assert status == Status.UNKNOWN
-
-    # empty json
-    status = Status.from_json({})
-    assert status == Status.UNKNOWN
+@pytest.mark.parametrize(
+    "json_input,expected_status",
+    [
+        ({"status": "STARTING"}, Status.STARTING),
+        ({"status": "UNKNOWN"}, Status.UNKNOWN),
+        ({"status": "not-a-status"}, Status.UNKNOWN),
+        ({}, Status.UNKNOWN),  # Empty JSON
+        ({"other_key": "value"}, Status.UNKNOWN),  # Missing "status" key
+    ],
+)
+def test_status_from_json(json_input, expected_status):
+    assert Status.from_json(json_input) == expected_status

--- a/sidecar/tests/app/query/test_status.py
+++ b/sidecar/tests/app/query/test_status.py
@@ -113,3 +113,19 @@ def test_status_history_status_event_json(
         "start_time": now,
         "end_time": now2,
     }
+
+
+def test_status_from_json():
+    # matching string
+    status = Status.from_json({"status": "STARTING"})
+    assert status == Status.STARTING
+    status = Status.from_json({"status": "UNKNOWN"})
+    assert status == Status.UNKNOWN
+
+    # non-mathcing string
+    status = Status.from_json({"status": "not-a-status"})
+    assert status == Status.UNKNOWN
+
+    # empty json
+    status = Status.from_json({})
+    assert status == Status.UNKNOWN


### PR DESCRIPTION
the failure we we're seeing was an issue with this kill signal failing with an http error. we wrap that in a try/except [in #88](https://github.com/private-attribution/draft/pull/88) to make sure it always cleans up, but this change makes sure we don't send extra kill signals that don't need to be sent. I'm not entirely convinced this would fix the issue without #88, but it seems like it could be the issue.


here are the logs from Helper 1 in the crash:
```
2024-09-26 08:31:47 | INFO     |    Helper 1 - thread 'query_runtime' panicked at library/core/src/panicking.rs:227:5:
2024-09-26 08:31:47 | INFO     |    Helper 1 - panic in a destructor during cleanup
2024-09-26 08:31:47 | INFO     |    Helper 1 - thread caused non-unwinding panic. aborting.
2024-09-26 08:31:47 | INFO     |    Helper 1 - sending kill signals
2024-09-26 08:31:47 | INFO     |    Helper 1 - sent post request: {"message":"Query already complete","query_id":"5931fdf3-5483-49d3-8407-7e6f0d94c7bb"}
2024-09-26 08:31:52 | ERROR    |    Helper 1 - The read operation timed out
2024-09-26 08:31:52 | INFO     |    Helper 1 - sending kill signals
2024-09-26 08:31:52 | INFO     |    Helper 1 - sent post request: {"message":"Query already complete","query_id":"5931fdf3-5483-49d3-8407-7e6f0d94c7bb"}
2024-09-26 08:31:52 | INFO     |    Helper 1 - sent post request: {"message":"Query already complete","query_id":"5931fdf3-5483-49d3-8407-7e6f0d94c7bb"}
2024-09-26 08:31:52 | INFO     |    Helper 1 - sent post request: {"message":"Query already complete","query_id":"5931fdf3-5483-49d3-8407-7e6f0d94c7bb"}
```

associated with this error on the report collector:
```
httpx.ReadTimeout: The read operation timed out
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced status checking process for improved clarity and efficiency.
	- Introduced a new method in the `Status` class to handle JSON input for status retrieval.
	- Added new methods in the `Helper` class for managing query statuses, including methods to construct URLs and manage query actions.
	- Added a property to return a list of helper instances that do not match the current role.

- **Bug Fixes**
	- Improved handling of unknown statuses by defaulting to `UNKNOWN` when the status key is missing.

- **Tests**
	- Added comprehensive tests for the new `from_json` method to ensure correct behavior with various JSON inputs.

- **Chores**
	- Updated project configuration to include `tomllib` as part of the extra standard libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->