### PR TITLE
Update rust version

### DIFF
--- a/sidecar/ansible/provision.yaml
+++ b/sidecar/ansible/provision.yaml
@@ -30,11 +30,11 @@
         executable: /bin/bash
       when: rustup_installed.rc != 0
 
-    - name: Update Rust to 1.80
-      command: rustup update 1.80.0
+    - name: Update Rust to 1.82
+      command: rustup update 1.82.0
 
-    - name: Set default to 1.80
-      command: rustup default 1.80.0
+    - name: Set default to 1.82
+      command: rustup default 1.82.0
 
     - name: Check if Git is installed
       command: git --version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Rust toolchain version from 1.80 to 1.82 for improved performance and compatibility. 

- **Bug Fixes**
	- Ensured that the default Rust version is now correctly set to 1.82.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->