### PR TITLE
update ansible git to only clone when repo isn't there

### DIFF
--- a/sidecar/ansible/provision.yaml
+++ b/sidecar/ansible/provision.yaml
@@ -56,11 +56,25 @@
       command: python3.11 -m pip install --upgrade pip
       become: yes
 
+    - name: Check if directory is a git repository
+      stat:
+        path: '{{ ansible_env.HOME }}/draft/.git'
+      register: git_repo
+
     - name: Clone repository if it doesn't exist
       git:
         repo: 'https://github.com/private-attribution/draft.git'
         dest: '{{ ansible_env.HOME }}/draft'
-        update: no
+      when: not git_repo.stat.exists
+
+
+    - name: Pull repository if it does exist
+      git:
+        repo: 'https://github.com/private-attribution/draft.git'
+        dest: '{{ ansible_env.HOME }}/draft'
+        clone: false
+        version: main
+      when: git_repo.stat.exists
 
     - name: Create virtualenv if it doesn't exist
       command: python3.11 -m venv .venv


### PR DESCRIPTION
small ansible change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Ansible playbook to check for existing Git repositories before cloning.
	- Added functionality to pull the latest changes if the repository already exists.
	- Included a check for Git installation, with automatic installation if not found.

- **Bug Fixes**
	- Removed outdated parameter from the repository cloning task for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->