### PR TITLE
fix ansible issues

### DIFF
--- a/sidecar/ansible/deploy.yaml
+++ b/sidecar/ansible/deploy.yaml
@@ -8,11 +8,13 @@
       args:
         chdir: '{{ ansible_env.HOME }}/draft'
         executable: /bin/bash
+      ignore_errors: true
 
     - name: Pull new commits from GitHub
       git:
         repo: 'https://github.com/private-attribution/draft.git'
         dest: '{{ ansible_env.HOME }}/draft'
+        clone: false
         update: yes
         version: main
 


### PR DESCRIPTION
this fixes two small errors with the deploy script:
1. `ignore_errors` allows the draft process to restart even if one of the nodes isn't running (e.g., has crashed)
2. `clone: false` fixes a change to the github api so that it only pulls main, and doesn't try to clone the repo (which fails, due to the repo already being there)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Ansible playbook to improve error handling and repository updates.
  
- **Bug Fixes**
	- Updated task for stopping the helper sidecar to allow execution to continue despite failures. 

- **Chores**
	- Adjusted parameters for pulling new commits from GitHub to prevent unnecessary cloning of the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->